### PR TITLE
Prevent RR crash when retracting facts with missing properties.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,15 @@
-/* MIT License
-
-rule-reactor: A light weight, fast, expressive forward chaining business rule engine leveraging JavaScript internals and Functions as objects rather than Rete.
-
-Copyright (c) 2016 Simon Y. Blackwell
-
-*/
-
-var uuid = require("uuid");
+    /* MIT License
+     rule-reactor: A light weight, fast, expressive forward chaining business rule engine leveraging JavaScript internals and Functions as objects rather than Rete.
+     Copyright (c) 2016 Simon Y. Blackwell
+     */
+    /* eslint-disable */
+    var uuid = require("uuid");
 //var hamsters = require("webhamsters/src/hamsters");
 //var Parallel = require("paralleljs");
 
-(function() {
-	"use strict";
+    (function() {
+        // "use strict";
+        // NOTE: DON'T USE STRICT - IT WILL CRASH THE RULE REACTOR IF IT RECEIVES ANY MESSAGE THAT DOES NOT HAVE ALL EXPECTED PROPERTIES USED IN RULES (activeKeys)
 	
 	var domains = global;
 	


### PR DESCRIPTION
When RR retracts the fact it tries to delete its properties (activeKeys) that it expects based on what properties are used in rule condition functions. Retracting facts without all expected activeKeys will cause RR to crash.